### PR TITLE
timeline: improve initial scroll positioning logic

### DIFF
--- a/client/src/features/timeline/pages/timeline.tsx
+++ b/client/src/features/timeline/pages/timeline.tsx
@@ -246,14 +246,20 @@ export const Timeline: React.FC<TimelineProps> = ({ timelineId }) => {
       const clientWidth = container.clientWidth;
 
       // Center on "Today"
-      const targetDate = new Date();
+      let targetDate = new Date();
+
+      if (nodes.length > 0) {
+        const startTimes = nodes.map((n) => new Date(n.startDate).getTime());
+        targetDate = new Date(Math.min(...startTimes));
+      }
+
       const xPos = getXPosition(viewStartDate, targetDate, scale);
       const initialScroll = xPos - clientWidth / 2;
 
       container.scrollLeft = initialScroll;
       hasInitializedScroll.current = true;
     }
-  }, [scale, viewStartDate, isLoading, nodes.length]);
+  }, [scale, viewStartDate, isLoading, nodes]);
 
   const itemsWithLanes = useMemo(() => {
     const sorted = [...uiItems].sort(


### PR DESCRIPTION
### 🔧 What’s Changed

<!-- A brief summary of what this PR does -->
- For populated timelines, the view now centers on the earliest node's start date instead of "Today," ensuring the user sees their content immediately upon load.

### 📌 Related Issue

Fixes #50


### ✅ Checklist

- [x]  Follow the correct **branch naming convention**.
- [x]  Include a **clear and descriptive title**.
- [x]  Reference the issue using `Fixes #<issue_number>`.
- [x]  Provide a concise but informative **description** of what was changed and why.
- [x]  Ensure your code:
    - [x]  Follows the project’s **folder structure and style guide**.
    - [x]  Includes **tests** or has a clear plan for testing (if applicable).
    - [x]  Passes **linters**, **formatting**, and **build checks**.
- [x]  Test your changes **locally** before submitting.
- [x]  Squash or organize commits meaningfully using `git rebase -i`.

